### PR TITLE
Encapsulating GridSynth config to a separate structure

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,84 @@
+use crate::common::ib_to_bf_prec;
+use crate::common::set_prec_bits;
+use dashu_float::round::mode::HalfEven;
+use dashu_float::FBig;
+use dashu_int::{IBig, UBig};
+use std::str::FromStr;
+
+#[derive(Debug)]
+pub struct GridSynthConfig {
+    pub theta: FBig<HalfEven>,
+    pub epsilon: FBig<HalfEven>,
+    pub diophantine_timeout: u128,
+    pub factoring_timeout: u128,
+    pub verbose: bool,
+    pub measure_time: bool,
+}
+
+pub fn parse_decimal_with_exponent(input: &str) -> Option<(IBig, IBig)> {
+    let input = input.trim();
+    let (sign, body) = if let Some(s) = input.strip_prefix('-') {
+        (-1, s)
+    } else if let Some(s) = input.strip_prefix('+') {
+        (1, s)
+    } else {
+        (1, input)
+    };
+
+    let (base_str, exp_str) = match body.split_once(['e', 'E']) {
+        Some((b, e)) => (b, e),
+        None => (body, "0"),
+    };
+
+    let parts: Vec<&str> = base_str.split('.').collect();
+    if parts.len() > 2 {
+        return None;
+    }
+    let int_part = parts[0];
+    let frac_part = if parts.len() == 2 { parts[1] } else { "" };
+    let digits = format!("{}{}", int_part, frac_part);
+    let decimal_digits = frac_part.len() as i32;
+
+    let exponent: i32 = exp_str.parse().ok()?;
+    let scale = exponent - decimal_digits;
+
+    let mut numerator = IBig::from_str(&digits).ok()? * sign;
+    let mut denominator = IBig::from(1);
+
+    match scale.cmp(&0) {
+        std::cmp::Ordering::Greater => {
+            numerator *= IBig::from(10u8).pow(scale as usize);
+        }
+        std::cmp::Ordering::Less => {
+            denominator = IBig::from(10u8).pow((-scale) as usize);
+        }
+        std::cmp::Ordering::Equal => {}
+    }
+
+    Some((numerator, denominator))
+}
+
+/// Creates the default config to easily call the code from other rust packages.
+pub fn config_from_theta_epsilon(theta: f64, epsilon: f64) -> GridSynthConfig {
+    let (theta_num, theta_den) = parse_decimal_with_exponent(&theta.to_string()).unwrap();
+    let theta = ib_to_bf_prec(theta_num) / ib_to_bf_prec(theta_den);
+    let (epsilon_num, epsilon_den) = parse_decimal_with_exponent(&epsilon.to_string()).unwrap();
+    let calculated_prec_bits =
+        12 * (epsilon_den.ilog(&UBig::from(10u8)) - epsilon_num.ilog(&UBig::from(10u8)));
+    let prec_bits: usize = calculated_prec_bits;
+    set_prec_bits(prec_bits);
+    let epsilon = ib_to_bf_prec(epsilon_num) / ib_to_bf_prec(epsilon_den);
+    let dtimeout = 200u128;
+    let factoring_timeout = 50u128;
+    let verbose = false;
+    let time = false;
+
+    GridSynthConfig {
+        theta,
+        epsilon,
+        diophantine_timeout: dtimeout,
+        factoring_timeout,
+        verbose,
+        measure_time: time,
+    }
+}

--- a/src/gridsynth.rs
+++ b/src/gridsynth.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 use crate::common::{cos_fbig, fb_with_prec, get_prec_bits, ib_to_bf_prec, sin_fbig};
+use crate::config::GridSynthConfig;
 use crate::diophantine::diophantine_dyadic;
 use crate::math::solve_quadratic;
 use crate::region::Ellipse;
@@ -379,30 +380,23 @@ fn gridsynth(
     )
 }
 
-pub fn gridsynth_gates(
-    theta: FBig<HalfEven>,
-    epsilon: FBig<HalfEven>,
-    diophantine_timeout: u128,
-    factoring_timeout: u128,
-    verbose: bool,
-    measure_time: bool,
-) -> String {
-    let start_total = if measure_time {
+pub fn gridsynth_gates(config: &GridSynthConfig) -> String {
+    let start_total = if config.measure_time {
         Some(Instant::now())
     } else {
         None
     };
 
     let u_approx = gridsynth(
-        theta,
-        epsilon,
-        diophantine_timeout,
-        factoring_timeout,
-        verbose,
-        measure_time,
+        config.theta.clone(),
+        config.epsilon.clone(),
+        config.diophantine_timeout,
+        config.factoring_timeout,
+        config.verbose,
+        config.measure_time,
     );
 
-    let start_decompose = if measure_time {
+    let start_decompose = if config.measure_time {
         Some(Instant::now())
     } else {
         None
@@ -410,7 +404,7 @@ pub fn gridsynth_gates(
     let gates = decompose_domega_unitary(u_approx);
 
     if let Some(start) = start_decompose {
-        if measure_time {
+        if config.measure_time {
             debug!(
                 "time of decompose_domega_unitary: {:.3} ms",
                 start.elapsed().as_secs_f64() * 1000.0
@@ -418,7 +412,7 @@ pub fn gridsynth_gates(
         }
     }
     if let Some(start) = start_total {
-        if measure_time {
+        if config.measure_time {
             debug!(
                 "total time: {:.3} ms",
                 start.elapsed().as_secs_f64() * 1000.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 pub mod common;
+pub mod config;
 pub mod diophantine;
 pub mod grid_op;
 pub mod gridsynth;


### PR DESCRIPTION
This PR essentially renames the `Args` class used in `main.rs` to `GridSynthConfig` and moves the config-building code to a separate file.

This simplifies how the code can be called from some external rust code, e.g.,

```rust
use rsgridsynth::config::config_from_theta_epsilon;
use rsgridsynth::gridsynth::gridsynth_gates;

...

let gridsynth_config = config_from_theta_epsilon(theta, epsilon);
let gates = gridsynth_gates(&gridsynth_config);
```

