### PR TITLE
Add GHA CI job to run build, fmt, clippy, and test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.80
+          - "1.80"
     steps:
       - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}


### PR DESCRIPTION
This commit adds a CI job to github actions that will run pre and post merge on any branch to run cargo build, cargo fmt, cargo clippy, and cargo test. This will ensure that any proposed change to rustiq-core will pass all of these checks to ensure the repo can always build, pass all the tests, and is following standard best practices for rust development.

The PR is literally copied from Matthew Treinish's PR for rustworkx-core: https://github.com/qiskit-community/rustiq-core/pull/3.

It should only be merged after #4 that fixes fmt + clippy issues present already, and in addition we should make sure that #3 does not introduce new clippy warnings either.