### PR TITLE
Implement up-to-phase algorithm

### DIFF
--- a/examples/interface.rs
+++ b/examples/interface.rs
@@ -17,7 +17,9 @@ fn main() {
     let theta = pi / 8.0;
     let epsilon = 1e-10;
     let seed = 1234;
-    let mut gridsynth_config = config_from_theta_epsilon(theta, epsilon, seed);
+    // This flag is currently ignored
+    let up_to_phase = false;
+    let mut gridsynth_config = config_from_theta_epsilon(theta, epsilon, seed, up_to_phase);
     let gates = gridsynth_gates(&mut gridsynth_config);
     println!("{}", gates);
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@ pub struct GridSynthConfig {
     pub verbose: bool,
     pub measure_time: bool,
     pub diophantine_data: DiophantineData,
+    pub up_to_phase: bool,
 }
 
 pub fn parse_decimal_with_exponent(input: &str) -> Option<(IBig, IBig)> {
@@ -69,7 +70,12 @@ pub fn parse_decimal_with_exponent(input: &str) -> Option<(IBig, IBig)> {
 }
 
 /// Creates the default config to easily call the code from other rust packages.
-pub fn config_from_theta_epsilon(theta: f64, epsilon: f64, seed: u64) -> GridSynthConfig {
+pub fn config_from_theta_epsilon(
+    theta: f64,
+    epsilon: f64,
+    seed: u64,
+    up_to_phase: bool,
+) -> GridSynthConfig {
     let (theta_num, theta_den) = parse_decimal_with_exponent(&theta.to_string()).unwrap();
     let theta = ib_to_bf_prec(theta_num) / ib_to_bf_prec(theta_den);
     let (epsilon_num, epsilon_den) = parse_decimal_with_exponent(&epsilon.to_string()).unwrap();
@@ -97,5 +103,6 @@ pub fn config_from_theta_epsilon(theta: f64, epsilon: f64, seed: u64) -> GridSyn
         verbose,
         measure_time: time,
         diophantine_data,
+        up_to_phase,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,13 @@ fn build_command() -> Command {
                 .short('g')
                 .action(clap::ArgAction::SetTrue),
         )
+        // We use `phase` rather than, say, `up_to_phase` to agree with original gridsynth.
+        .arg(
+            Arg::new("phase")
+                .long("phase")
+                .short('p')
+                .action(clap::ArgAction::SetTrue),
+        )
 }
 
 fn parse_arguments(matches: &clap::ArgMatches) -> GridSynthConfig {
@@ -127,6 +134,7 @@ fn parse_arguments(matches: &clap::ArgMatches) -> GridSynthConfig {
         .unwrap();
     let verbose = matches.get_flag("verbose");
     let measure_time = matches.get_flag("time");
+    let up_to_phase = matches.get_flag("phase");
 
     let seed = matches.get_one::<String>("seed").unwrap().parse().unwrap();
     let rng: StdRng = SeedableRng::seed_from_u64(seed);
@@ -142,5 +150,6 @@ fn parse_arguments(matches: &clap::ArgMatches) -> GridSynthConfig {
         verbose,
         measure_time,
         diophantine_data,
+        up_to_phase,
     }
 }

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024-2025 Shun Yamamoto and Nobuyuki Yoshioka, and IBM
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-use crate::common::{get_prec_bits, ib_to_bf_prec};
+use crate::common::{fb_with_prec, get_prec_bits, ib_to_bf_prec};
 use dashu_float::round::mode;
 use dashu_float::Context;
 use dashu_float::{round::mode::HalfEven, FBig};
@@ -14,6 +14,14 @@ pub fn sqrt2() -> FBig<HalfEven> {
     let x = ib_to_bf_prec(IBig::from(2));
     let a: FBig<HalfEven> = ctx.sqrt(x.repr()).value();
     a
+}
+
+// This may be wasteful because of the allocation
+pub fn sqrt_fbig(x: &FBig<HalfEven>) -> FBig<HalfEven> {
+    let ctx: Context<mode::HalfEven> = Context::<mode::HalfEven>::new(get_prec_bits());
+    let x = fb_with_prec(x.clone());
+    let sx: FBig<HalfEven> = ctx.sqrt(x.repr()).value();
+    sx
 }
 
 pub fn ntz(n: &IBig) -> i64 {

--- a/src/odgp.rs
+++ b/src/odgp.rs
@@ -4,15 +4,11 @@
 use crate::common::ib_to_bf_prec;
 use crate::math::{floorlog, pow_sqrt2, sqrt2};
 use crate::region::Interval;
+use crate::ring::z_root_two::LAMBDA;
 use crate::ring::{DRootTwo, ZRootTwo};
 use dashu_float::round::mode::HalfEven;
 use dashu_float::FBig;
 use dashu_int::IBig;
-
-const LAMBDA: ZRootTwo = ZRootTwo {
-    a: IBig::ONE,
-    b: IBig::ONE,
-};
 
 pub fn solve_odgp(i: Interval, j: Interval) -> impl Iterator<Item = ZRootTwo> {
     // Can't return two different iterator types. So we can't do this check.

--- a/src/ring/d_root_two.rs
+++ b/src/ring/d_root_two.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2024-2025 Shun Yamamoto and Nobuyuki Yoshioka, and IBM
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
+use dashu_base::Sign;
 use dashu_float::round::mode::HalfEven;
 use dashu_float::FBig;
 use dashu_int::IBig;
@@ -16,6 +17,30 @@ pub struct DRootTwo {
     pub(crate) alpha: ZRootTwo,
     pub(crate) k: i64,
 }
+
+pub const ONE: DRootTwo = DRootTwo {
+    alpha: ZRootTwo {
+        a: IBig::ONE,
+        b: IBig::ZERO,
+    },
+    k: 0,
+};
+
+pub const DELTA_SQUARED: DRootTwo = DRootTwo {
+    alpha: ZRootTwo {
+        a: IBig::from_parts_const(Sign::Positive, 2),
+        b: IBig::ONE,
+    },
+    k: 0,
+};
+
+pub const DELTA_SQUARED_M: DRootTwo = DRootTwo {
+    alpha: ZRootTwo {
+        a: IBig::from_parts_const(Sign::Positive, 2),
+        b: IBig::NEG_ONE,
+    },
+    k: 0,
+};
 
 impl DRootTwo {
     pub fn new(alpha: ZRootTwo, k: i64) -> Self {

--- a/src/ring/mod.rs
+++ b/src/ring/mod.rs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 mod d_omega;
-mod d_root_two;
+pub mod d_root_two;
 mod z_omega;
-mod z_root_two;
+pub mod z_root_two;
 
 pub use d_omega::DOmega;
 pub use d_root_two::DRootTwo;

--- a/src/ring/z_root_two.rs
+++ b/src/ring/z_root_two.rs
@@ -4,6 +4,7 @@
 use crate::common::ib_to_bf_prec;
 use crate::math::{floorsqrt, rounddiv, sign, sqrt2};
 use crate::ring::ZOmega;
+use dashu_base::Sign;
 use dashu_float::round::mode::HalfEven;
 use dashu_float::FBig;
 use dashu_int::IBig;
@@ -17,6 +18,31 @@ pub struct ZRootTwo {
     pub(crate) a: IBig,
     pub(crate) b: IBig,
 }
+
+pub const ONE: ZRootTwo = ZRootTwo {
+    a: IBig::ONE,
+    b: IBig::ZERO,
+};
+
+pub const DELTA_SQUARED: ZRootTwo = ZRootTwo {
+    a: IBig::from_parts_const(Sign::Positive, 2),
+    b: IBig::ONE,
+};
+
+// Absolute value squared of root two conjugate of δ.
+pub const DELTA_SQUARED_M: ZRootTwo = ZRootTwo {
+    a: IBig::from_parts_const(Sign::Positive, 2),
+    b: IBig::NEG_ONE,
+};
+
+// See Definition 3.5 on pg 3 of R+S
+// Careful! There is a different, unrelated defintion of lambda in
+// the discussion in Definition 9.1 on page 19 of R+S. It is in fact
+// the fixed phase factor used in the up-to-phase algorithm.
+pub const LAMBDA: ZRootTwo = ZRootTwo {
+    a: IBig::ONE,
+    b: IBig::ONE,
+};
 
 impl ZRootTwo {
     pub fn new(a: IBig, b: IBig) -> Self {

--- a/src/to_upright.rs
+++ b/src/to_upright.rs
@@ -8,14 +8,11 @@ use crate::common::ib_to_bf_prec;
 use crate::grid_op::{EllipsePair, GridOp};
 use crate::math::{floorsqrt, log};
 use crate::region::{Ellipse, Rectangle};
-use crate::ring::{ZOmega, ZRootTwo};
+use crate::ring::z_root_two::LAMBDA;
+use crate::ring::ZOmega;
 use crate::tdgp::Region;
 use dashu_int::IBig;
 use num_traits::Pow;
-const LAMBDA: ZRootTwo = ZRootTwo {
-    a: IBig::ONE,
-    b: IBig::ONE,
-};
 
 fn reduction(
     ellipse_pair: EllipsePair,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10,7 +10,8 @@ fn simple_test() {
     let theta = pi / 8.0;
     let epsilon = 1e-10;
     let seed = 1234;
-    let mut gridsynth_config = config_from_theta_epsilon(theta, epsilon, seed);
+    let up_to_phase = false;
+    let mut gridsynth_config = config_from_theta_epsilon(theta, epsilon, seed, up_to_phase);
     let gates = gridsynth_gates(&mut gridsynth_config);
     let expected_gates = "HTHTSHTSHTHTSHTHTSHTHTHTSHTSHTHTHTHTHTHTSHTSHTHTSHTSHTSHTSHTHTSHTSHTSHTHTHTHTHTHTSHTSHTHTSHTSHTSHTHTHTSHTSHTSHTSHTSHTSHTSHTHTHTHTHTSHTSHTSHTSHTSHTSHTHTHTHTHTSHTHTSHTHTHTSHTSHTSHTHTSHTSHTHTSHTHTSHTSHTHTSHTHTHTSHTSHTSHTSHTHTHTHTSHTHTHTSHTHTSHTHTHTSHTHTSHTHTSHTXSSWWW";
     assert_eq!(gates, expected_gates);


### PR DESCRIPTION
This PR implements the algorithm that allows synthesizing the z-rotation up to a global phase.

This is a work in process. The first part (probably less than half) is done; setting up data structures and methods. The second part is writing the larger algorithm that uses the data structure.

closes #9
