### PR TITLE
Add more integration tests

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -14,7 +14,6 @@ fn simple_test() {
     assert_eq!(gates, expected_gates);
 }
 
-
 #[test]
 #[ignore]
 fn simple_test2() {
@@ -24,11 +23,7 @@ fn simple_test2() {
 
     let gates1 = "HTHTSHTSHTHTSHTHTSHTHTHTSHTSHTHTHTHTHTHTSHTSHTHTSHTSHTSHTSHTHTSHTSHTSHTHTHTHTHTHTSHTSHTHTSHTSHTSHTHTHTSHTSHTSHTSHTSHTSHTSHTHTHTHTHTSHTSHTSHTSHTSHTSHTHTHTHTHTSHTHTSHTHTHTSHTSHTSHTHTSHTSHTHTSHTHTSHTSHTHTSHTHTHTSHTSHTSHTSHTHTHTHTSHTHTHTSHTHTSHTHTHTSHTHTSHTHTSHTXSSWWW";
 
-    let test_inputs = vec![
-        (1234, gates1),
-        (101, gates1),
-        (1, gates1),
-    ];
+    let test_inputs = vec![(1234, gates1), (101, gates1), (1, gates1)];
 
     for (seed, expected_gates) in test_inputs {
         let mut gridsynth_config = config_from_theta_epsilon(theta, epsilon, seed);
@@ -36,7 +31,6 @@ fn simple_test2() {
         assert_eq!(gates, expected_gates, "Test failed for seed: {}", seed);
     }
 }
-
 
 //#[ignore]
 #[test]


### PR DESCRIPTION
This PR	reveals	bugs. I	have added tests to the	integration test suite. Currently, I have two tests flagged with #[ignore] so that they	will not run by default.

The bugs seem to be related to some kind of mutable state. We expect that the result of creating a configuration and doing a decomposition does not depend on previous calls. But in fact it does.

As it is, the test suite passes every time I run it.

In fact, the following three invocations run without error for me.

> cargo test

> cargo test --test '*'

> cargo test --test '*' -- --ignored

But this invocation will fail in various ways. Either by throwing an error, or by running for a couple of minutes; until I terminate the test

> cargo test --test '*' -- --include-ignored

There are several other interesting combinations that you can find. For example simple_test2 test three different seeds that all give the same decomposition. But if you run only the middle pair (comment out the first and third), then you find a different decomposition and a test failure