### PR TITLE
Bump nalgebra to latest release and MSRV to 1.87

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - "1.82"
+          - "1.87"
     steps:
       - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/qiskit-community/rsgridsynth"
 readme = "README.md"
 keywords = ["quantum", "benchmarking"]
 categories = ["algorithms", "science"]
-rust-version = "1.82"
+rust-version = "1.87"
 
 [[bin]]
 name = "rsgridsynth"
@@ -21,7 +21,7 @@ name = "rsgridsynth"
 path = "src/lib.rs"
 
 [dependencies]
-nalgebra = { version = "0.33", features = ["macros"] }
+nalgebra = { version = "0.34", features = ["macros"] }
 once_cell = "1.21"
 num-traits = "0.2"
 rand = "0.9"

--- a/src/diophantine.rs
+++ b/src/diophantine.rs
@@ -39,7 +39,7 @@ fn is_small_prime(n: u64) -> bool {
     match n {
         0 | 1 => false,
         2 => true,
-        _ if n % 2 == 0 => false,
+        _ if n.is_multiple_of(2) => false,
         3..=16 => [3, 5, 7, 11, 13].contains(&n),
         _ => {
             let witnesses = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37];
@@ -51,7 +51,7 @@ fn is_small_prime(n: u64) -> bool {
 fn miller_rabin_deterministic(n: u64, witnesses: &[u64]) -> bool {
     let mut d = n - 1;
     let mut r = 0;
-    while d % 2 == 0 {
+    while d.is_multiple_of(2) {
         d /= 2;
         r += 1;
     }
@@ -401,7 +401,7 @@ fn find_factor<R: Rng + ?Sized>(
                 if start.elapsed().as_millis() >= timeout_ms {
                     break;
                 }
-                if n_u64 % i == 0 {
+                if n_u64.is_multiple_of(i) {
                     let result = Some(IBig::from(i));
                     if let Ok(mut cache) = FACTOR_CACHE.try_lock() {
                         cache.insert(n.clone(), result.clone());


### PR DESCRIPTION
This commit bumps the nalgebra version used by rsgridsynth to the latest release 0.34. To use it requires bumping the MSRV to 1.87, so this commit increases the MSRV accordingly.