### PR TITLE
Release: prepare 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsgridsynth"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Shun Yamamoto", "Nobuyuki Yoshioka", "IBM"]
 license = "MIT"


### PR DESCRIPTION
Bump version to 0.2.1 for the patch release shipping the diophantine cache-key fix (#40), the timeout-preservation fix (#38), and the nalgebra/MSRV bump (#36) since 0.2.0.