### PR TITLE
Release: prepare 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rsgridsynth"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "dashu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsgridsynth"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Shun Yamamoto", "Nobuyuki Yoshioka", "IBM"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Bump version to **0.2.2** for the patch release covering everything merged since `v0.2.1`.

## Changes since 0.2.1

- clap upgraded to 4.6.4 and the CLI moved behind a `cli` feature flag (#43)
- CI workflow now builds the binary with `--all-features --bin rsgridsynth`
- `Cargo.lock` synced with nalgebra 0.34
